### PR TITLE
section/7 : complete security part #7

### DIFF
--- a/apigateway-service/pom.xml
+++ b/apigateway-service/pom.xml
@@ -50,6 +50,46 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- JWT 토큰 라이브러리 -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>3.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+
+
+		<!-- Spring Security (JWT 통합 시 필요) -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>
@@ -62,6 +102,7 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+
 
 	<build>
 		<plugins>

--- a/apigateway-service/src/main/java/com/example/apigateway_service/config/WebConfig.java
+++ b/apigateway-service/src/main/java/com/example/apigateway_service/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.example.apigateway_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .build();
+    }
+}

--- a/apigateway-service/src/main/java/com/example/apigateway_service/filter/AuthorizationHeaderFilter.java
+++ b/apigateway-service/src/main/java/com/example/apigateway_service/filter/AuthorizationHeaderFilter.java
@@ -1,0 +1,78 @@
+package com.example.apigateway_service.filter;
+
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHeaders;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+@Slf4j
+public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<AuthorizationHeaderFilter.Config> {
+    private Environment environment;
+
+    public AuthorizationHeaderFilter(Environment environment) {
+        super(Config.class);
+        this.environment = environment;
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return ((exchange, chain) -> {
+            ServerHttpRequest request = exchange.getRequest();
+            if (!request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
+                return onError(exchange, "no authorization header", HttpStatus.UNAUTHORIZED);
+            }
+            String authorizationHeader = request.getHeaders()
+                    .get(org.springframework.http.HttpHeaders.AUTHORIZATION).get(0);
+            String jwt = authorizationHeader.replace("Bearer ", "");
+
+            if (!isJwtValid(jwt)) {
+                return onError(exchange, "token is not valid", HttpStatus.UNAUTHORIZED);
+            }
+            return chain.filter(exchange);
+        });
+    }
+
+    private boolean isJwtValid(String jwt) {
+        boolean returnValue = true;
+        String subject = null;
+        try {
+            log.info("jwt = {}", jwt);
+            subject = Jwts.parserBuilder()
+                    .setSigningKey(environment.getProperty("token.secret"))
+                    .build()
+                    .parseClaimsJws(jwt)
+                    .getBody()
+                    .getSubject();
+            log.info("subject = {}", subject);
+        } catch (Exception exception) {
+            returnValue = false;
+        }
+        if (subject == null || subject.isEmpty()) {
+            returnValue = false;
+        }
+        return returnValue;
+    }
+
+    private Mono<Void> onError(ServerWebExchange exchange, String err, HttpStatus httpStatus) {
+        ServerHttpResponse response = exchange.getResponse();
+        response.setStatusCode(httpStatus);
+
+        log.error(err);
+        return response.setComplete();
+    }
+
+    public static class Config{
+
+    }
+
+}

--- a/apigateway-service/src/main/resources/application-test.yml
+++ b/apigateway-service/src/main/resources/application-test.yml
@@ -1,0 +1,47 @@
+server:
+  port: 8000
+
+eureka:
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+
+spring:
+  application:
+    name: gateway-service
+  cloud:
+    gateway:
+      default-filters:
+        - name: GlobalFilter
+          args:
+            baseMessage: Spring Cloud Gateway GlobalFilter
+            preLogger: true
+            postLogger: true
+      routes:
+        - id: user-service
+          uri: lb://USER-SERVICE    # -> 동적 주소 적용 가능(static한 주소를 사용하지 않아도 되는 이점)
+          predicates:
+            - Path=/user-service/**
+        - id: first-service
+          uri: lb://MY-FIRST-SERVICE
+          predicates:
+            - Path=/first-service/**
+          filters:
+#            - AddRequestHeader=first-request, first-request-header2
+#            - AddResponseHeader=first-response, first-response-header2
+            - CustomFilter
+        - id: second-service
+          uri: lb://MY-SECOND-SERVICE
+          predicates:
+            - Path=/second-service/**
+          filters:
+#            - AddRequestHeader=second-request, second-request-header2
+#            - AddResponseHeader=second-response, second-response-header2
+            - name: CustomFilter
+            - name: LoggingFilter
+              args:
+                baseMessage: hi. there
+                preLogger: true
+                postLogger: true

--- a/apigateway-service/src/main/resources/application.yml
+++ b/apigateway-service/src/main/resources/application.yml
@@ -20,37 +20,55 @@ spring:
             preLogger: true
             postLogger: true
       routes:
-        - id: user-service
-          uri: lb://USER-SERVICE    # -> 동적 주소 적용 가능(static한 주소를 사용하지 않아도 되는 이점)
-          predicates:
-            - Path=/user-service/**
+        ### CATALOG ###
         - id: catalog-service
           uri: lb://CATALOG-SERVICE
           predicates:
             - Path=/catalog-service/**
+        ### ORDER ###
         - id: order-service
           uri: lb://ORDER-SERVICE
           predicates:
             - Path=/order-service/**
-        - id: first-service
-          uri: lb://MY-FIRST-SERVICE
+        ### USER ###
+        - id: user-service
+          uri: lb://USER-SERVICE
           predicates:
-            - Path=/first-service/**
+            - Path=/user-service/login
+            - Method=POST
           filters:
-#            - AddRequestHeader=first-request, first-request-header2
-#            - AddResponseHeader=first-response, first-response-header2
-            - CustomFilter
-        - id: second-service
-          uri: lb://MY-SECOND-SERVICE
-          predicates:
-            - Path=/second-service/**
-          filters:
-#            - AddRequestHeader=second-request, second-request-header2
-#            - AddResponseHeader=second-response, second-response-header2
-            - name: CustomFilter
-            - name: LoggingFilter
-              args:
-                baseMessage: hi. there
-                preLogger: true
-                postLogger: true
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/user-service/(?<segment>.*), /$\{segment}
 
+        - id: user-service
+          uri: lb://USER-SERVICE
+          predicates:
+            - Path=/user-service/users
+            - Method=POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/user-service/(?<segment>.*), /$\{segment}
+
+        - id: user-service
+          uri: lb://USER-SERVICE
+          predicates:
+            - Path=/user-service/welcome, /user-service/health_check
+            - Method=GET
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/user-service/(?<segment>.*), /$\{segment}
+
+        - id: user-service
+          uri: lb://USER-SERVICE
+          predicates:
+            - Path=/user-service/users/**
+            - Method=GET
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/user-service/(?<segment>.*), /$\{segment}
+            - AuthorizationHeaderFilter
+
+
+
+token:
+  secret: 53ffbe9051285a971c739c855e892e5041ba6128b85a3f88580152b8125b8d4bd4c1ad5e638db9521f64ddff221869963373d2fc80fcc18b742df31f5ea9a2a3

--- a/project/user-service/pom.xml
+++ b/project/user-service/pom.xml
@@ -43,11 +43,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<!-- Spring Security -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
 
 		<!-- MySQL Connector -->
 		<dependency>
@@ -75,6 +70,40 @@
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>
+		</dependency>
+
+		<!-- Spring Security -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<!-- JWT Token Library -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>3.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>3.0.2</version>
 		</dependency>
 
 		<!-- Spring Boot Starter Test -->

--- a/project/user-service/src/main/java/com/example/user_service/UserServiceApplication.java
+++ b/project/user-service/src/main/java/com/example/user_service/UserServiceApplication.java
@@ -13,9 +13,4 @@ public class UserServiceApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(UserServiceApplication.class, args);
 	}
-	@Bean
-	public BCryptPasswordEncoder passwordEncoder() {
-		return new BCryptPasswordEncoder();
-	}
-
 }

--- a/project/user-service/src/main/java/com/example/user_service/controller/UserController.java
+++ b/project/user-service/src/main/java/com/example/user_service/controller/UserController.java
@@ -23,7 +23,7 @@ import static org.springframework.http.HttpStatus.OK;
 
 @Slf4j
 @RestController
-@RequestMapping("/user-service")
+@RequestMapping
 public class UserController {
 
     private Environment env;

--- a/project/user-service/src/main/java/com/example/user_service/jpa/UserRepository.java
+++ b/project/user-service/src/main/java/com/example/user_service/jpa/UserRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface UserRepository extends CrudRepository<UserEntity, Long> {
     UserEntity findByUserId(String userId);
+
+    UserEntity findByEmail(String username);
 }

--- a/project/user-service/src/main/java/com/example/user_service/security/AuthenticationFilter.java
+++ b/project/user-service/src/main/java/com/example/user_service/security/AuthenticationFilter.java
@@ -1,0 +1,79 @@
+package com.example.user_service.security;
+
+
+import com.example.user_service.dto.UserDto;
+import com.example.user_service.service.UserService;
+import com.example.user_service.vo.RequestLogin;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.discovery.converters.Auto;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final UserService userService;
+    private final Environment env;
+
+    @Override
+    public void setAuthenticationManager(AuthenticationManager authenticationManager) {
+        super.setAuthenticationManager(authenticationManager);
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+
+        try {
+            RequestLogin creds = new ObjectMapper().readValue(request.getInputStream(), RequestLogin.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            creds.getEmail(), creds.getPassword(), new ArrayList<>()
+                    )
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+                                            HttpServletResponse response,
+                                            FilterChain chain,
+                                            Authentication authResult) throws IOException, ServletException {
+        String username = ((User) authResult.getPrincipal()).getUsername();
+        UserDto userDto = userService.getUserDetailsByEmail(username);
+
+        log.info("env.token.expiration_time : {}", env.getProperty("token.expiration_time"));
+        log.info("env.token.secret : {}", env.getProperty("token.secret"));
+        String token = Jwts.builder()
+                .setSubject(userDto.getUserId())
+                .setExpiration(new Date(System.currentTimeMillis()
+                        + Long.parseLong(env.getProperty("token.expiration_time"))))
+                .signWith(SignatureAlgorithm.HS512, env.getProperty("token.secret"))
+                .compact();
+
+        response.addHeader("token", token);
+        response.addHeader("userDetails", userDto.getUserId());
+    }
+}

--- a/project/user-service/src/main/java/com/example/user_service/security/PasswordConfig.java
+++ b/project/user-service/src/main/java/com/example/user_service/security/PasswordConfig.java
@@ -1,0 +1,13 @@
+package com.example.user_service.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/project/user-service/src/main/java/com/example/user_service/security/WebSecurity.java
+++ b/project/user-service/src/main/java/com/example/user_service/security/WebSecurity.java
@@ -51,7 +51,7 @@ public class WebSecurity {
                                     log.info("client ip is = {}", clientIp);
 
                                     // 허용된 IP 리스트
-                                    String[] allowedIps = {"127.0.0.1","172.20.10.2"};
+                                    String[] allowedIps = {"127.0.0.1","172.20.10.2", "0:0:0:0:0:0:0:1"};
 
                                     // IP가 허용된 리스트에 포함되어 있는지 확인
                                     boolean isAllowed = Arrays.asList(allowedIps).contains(clientIp);

--- a/project/user-service/src/main/java/com/example/user_service/security/WebSecurity.java
+++ b/project/user-service/src/main/java/com/example/user_service/security/WebSecurity.java
@@ -2,42 +2,105 @@ package com.example.user_service.security;
 
 import com.example.user_service.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.AuthenticationFilter;
+import org.springframework.security.web.access.expression.WebExpressionAuthorizationManager;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.Arrays;
 
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
+@Slf4j
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class WebSecurity {
 
-//    private final UserService userService;
-//    private final BCryptPasswordEncoder bCryptPasswordEncoder;
-//    private final Environment environment;
+    private final UserService userService;
+    private final Environment env;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           AuthenticationManager authenticationManager,
+                                           UserService userService) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(request ->{
-                    request.requestMatchers(antMatcher("/actuator/**")).permitAll();
-                    request.requestMatchers("/user-service/**").permitAll();
-                    request.requestMatchers(antMatcher("/user-service/users/**")).permitAll();});
-//        http.addFilterBefore(customAuthenticationFilter(http), UsernamePasswordAuthenticationFilter.class);
+                .authorizeHttpRequests(authorize ->
+                        authorize
+//                                .requestMatchers("/users/**", "/users").permitAll()
+                                .requestMatchers("/actuator/**").permitAll()
+                                .requestMatchers("/health_check", "/welcome").permitAll()
+                                .requestMatchers(antMatcher(HttpMethod.POST,"/users")).permitAll()
+                                .requestMatchers("/error/**").permitAll()
+                                .requestMatchers("/users", "/users/**").access((authentication, request) -> {
+                                    String clientIp = request.getRequest().getRemoteAddr();
+                                    log.info("client ip is = {}", clientIp);
+
+                                    // 허용된 IP 리스트
+                                    String[] allowedIps = {"127.0.0.1","172.20.10.2"};
+
+                                    // IP가 허용된 리스트에 포함되어 있는지 확인
+                                    boolean isAllowed = Arrays.asList(allowedIps).contains(clientIp);
+
+                                    return new AuthorizationDecision(isAllowed);
+                                })
+//                                .anyRequest().authenticated()
+                )
+                .authenticationManager(authenticationManager)
+                // 사용자 세션 저장하지 않음
+                .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // 응답 헤더에 X-Frame-Options 추가 - 클릭재킹 공격 방어 - 동일 출처만 <iframe> 로드 가능.
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .addFilter(customAuthenticationFilter(authenticationManager));
 
         return http.build();
     }
+
+    /**
+     * authenticationManager bean 생성
+     * @param http HttpSecurity
+     * @return authenticationManager bean
+     */
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http,
+                                                       UserService userService,
+                                                       BCryptPasswordEncoder passwordEncoder) throws Exception {
+        AuthenticationManagerBuilder authenticationManagerBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        authenticationManagerBuilder.userDetailsService(userService).passwordEncoder(passwordEncoder);
+
+        return authenticationManagerBuilder.build();
+    }
+
+    /**
+     * customAuthenticationFilter bean 생성
+     * @return customAuthenticationFilter bean
+     */
+    @Bean
+    public AuthenticationFilter customAuthenticationFilter(AuthenticationManager authenticationManager) {
+        AuthenticationFilter authenticationFilter = new AuthenticationFilter(userService, env);
+        authenticationFilter.setAuthenticationManager(authenticationManager);
+        return authenticationFilter;
+    }
+
+    /**
+     * 비밀번호 암호화 모듈
+     * @return 암호화 bean
+     */
+
 
 
 }

--- a/project/user-service/src/main/java/com/example/user_service/service/UserService.java
+++ b/project/user-service/src/main/java/com/example/user_service/service/UserService.java
@@ -2,11 +2,16 @@ package com.example.user_service.service;
 
 import com.example.user_service.dto.UserDto;
 import com.example.user_service.jpa.UserEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
-public interface UserService {
+public interface UserService
+        extends UserDetailsService {
     UserDto createUser(UserDto userDto);
 
     UserDto getUserByUserId(String userId);
 
     Iterable<UserEntity> getUsersByAll();
+
+    UserDto getUserDetailsByEmail(String username);
 }

--- a/project/user-service/src/main/java/com/example/user_service/service/UserServiceImpl.java
+++ b/project/user-service/src/main/java/com/example/user_service/service/UserServiceImpl.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.spi.MatchingStrategy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -51,5 +54,24 @@ public class UserServiceImpl implements UserService{
     @Override
     public Iterable<UserEntity> getUsersByAll() {
         return userRepository.findAll();
+    }
+
+    @Override
+    public UserDto getUserDetailsByEmail(String username) {
+        UserEntity userEntity = userRepository.findByEmail(username);
+        if (userEntity == null) {
+            throw new RuntimeException("not found user");
+        }
+        return new ModelMapper().map(userEntity, UserDto.class);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) {
+        UserEntity userEntity = userRepository.findByEmail(username);
+
+        if (userEntity == null) {
+            throw new UsernameNotFoundException(username);
+        }
+        return new User(userEntity.getEmail(), userEntity.getEncryptedPwd(), new ArrayList<>());
     }
 }

--- a/project/user-service/src/main/java/com/example/user_service/vo/RequestLogin.java
+++ b/project/user-service/src/main/java/com/example/user_service/vo/RequestLogin.java
@@ -1,0 +1,19 @@
+package com.example.user_service.vo;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class RequestLogin {
+    @NotNull(message = "Email cannot be null")
+    @Size(min = 2, message = "cannot be less than 2 char")
+    @Email
+    private String email;
+    @NotNull(message = "cannot be null")
+    @Size(min = 8, message = "cannot be less than 8 char")
+    private String password;
+
+
+}

--- a/project/user-service/src/main/resources/application.yml
+++ b/project/user-service/src/main/resources/application.yml
@@ -25,3 +25,7 @@ eureka:
 
 greeting:
   message: Welcome to the Simple E-commerce.
+
+token:
+  expiration_time: 86400000
+  secret: 53ffbe9051285a971c739c855e892e5041ba6128b85a3f88580152b8125b8d4bd4c1ad5e638db9521f64ddff221869963373d2fc80fcc18b742df31f5ea9a2a3


### PR DESCRIPTION
# Issue
- https://github.com/Han-Jeong/msa-study/issues/7
# Contents
jwt token 발급까지는 원래 흐름과 비슷하다. user-service에서 user 정보와 관련해서 토큰을 인코딩하여 login 메서드르 실행 시에 바디에 토큰 정보를 뿌리도록 되어있다.
원래라면 원하는 api를 permit하거나 authenticated 하여 인증/비인증 api를 가르지만, msa의 경우 토큰의 유효성을 gateway에서 검증한다. 검증되었을 때는 access()를 통해 gateway ip를 허용시키도록 되어있다. 
이렇게 설정되면, gateway를 통한 path가 아닌 user-service 포트를 통해 직접 api를 호출하게된다면 인증처리를 별도로 하지 않아도 된다.(대신 로컬 ip도 허용해줘야한다.)